### PR TITLE
Fix media-query for retina

### DIFF
--- a/src/sass/article.scss
+++ b/src/sass/article.scss
@@ -96,7 +96,7 @@
         fill: $articleInfo;
       }
 
-      @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+      @media (-webkit-min-device-pixel-ratio: 2) and (max-width: 1000px), (min-resolution: 192dpi) and (max-width: 1000px) {
         font-size: 2rem;
 
         .icon-details {
@@ -136,7 +136,7 @@
       color: $articlePColor;
     }
 
-    @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+    @media (-webkit-min-device-pixel-ratio: 2) and (max-width: 992px), (min-resolution: 192dpi) and (max-width: 992px) {
       h1 {
         font-size: 4rem;
         line-height: 5rem;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -388,7 +388,7 @@ main {
   width: 20px;
 }
 
-@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+@media (-webkit-min-device-pixel-ratio: 2) and (max-width: 992px), (min-resolution: 192dpi) and (max-width: 992px) {
   main {
     .masonry {
       -moz-column-width: 35em;


### PR DESCRIPTION
Fix media-query to do not show increased fonts on retina device with a screen width more than 992px

Fix #4